### PR TITLE
Ensure iterables comparison is symmetrical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # fast-equals CHANGELOG
 
-## 1.0.1
+## 1.0.2
+* Fix symmetrical comparison of iterables
+* Reduce footprint
 
+## 1.0.1
 * Prevent babel transpilation of `typeof` into helper for faster runtime
 
 ## 1.0.0
-
 * Initial release

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src="https://img.shields.io/badge/coverage-100%25-brightgreen.svg"/>
 <img src="https://img.shields.io/badge/license-MIT-blue.svg"/>
 
-Perform [blazing fast](#benchmarks) equality comparisons (either deep or shallow) on two objects passed. It has no dependencies, and is ~1.2Kb when minified and gzipped.
+Perform [blazing fast](#benchmarks) equality comparisons (either deep or shallow) on two objects passed. It has no dependencies, and is ~1.1Kb when minified and gzipped.
 
 Unlike most equality validation libraries, the following types are handled out-of-the-box:
 * `NaN`
@@ -122,15 +122,15 @@ All benchmarks are based on averages of running comparisons based on the followi
 
 |                        | Operations / second | Relative margin of error |
 |------------------------|---------------------|--------------------------|
-| **fast-equals**        | **201,249**         | **0.60%**                |
-| nano-equal             | 119,409             | 1.38%                    |
-| fast-deep-equal        | 92,048              | 0.44%                    |
-| shallow-equal-fuzzy    | 80,478              | 0.58%                    |
-| underscore.isEqual     | 49,145              | 0.49%                    |
-| deep-equal             | 31,906              | 0.73%                    |
-| lodash.isEqual         | 24,293              | 0.50%                    |
-| deep-eql               | 14,600              | 0.74%                    |
-| assert.deepStrictEqual | 454                 | 1.32%                    |
+| **fast-equals**        | **190,315**         | **0.57%**                |
+| nano-equal             | 123,255             | 0.76%                    |
+| fast-deep-equal        | 102,990             | 0.50%                    |
+| shallow-equal-fuzzy    | 83,553              | 0.47%                    |
+| underscore.isEqual     | 51,321              | 0.51%                    |
+| deep-equal             | 32,694              | 0.80%                    |
+| lodash.isEqual         | 25,872              | 0.59%                    |
+| deep-eql               | 14,804              | 0.81%                    |
+| assert.deepStrictEqual | 448                 | 1.42%                    |
 
 Caveats that impact the benchmark:
 * `fast-deep-equal` does not support `NaN`

--- a/src/comparator.js
+++ b/src/comparator.js
@@ -1,8 +1,8 @@
 // utils
-import {isFunction, isNAN, toPairs} from './utils';
+import {toPairs} from './utils';
 
 const createComparator = (createIsEqual) => {
-  const isEqualComparator = isFunction(createIsEqual) ? createIsEqual(comparator) : comparator; // eslint-disable-line
+  const isEqual = typeof createIsEqual === 'function' ? createIsEqual(comparator) : comparator; // eslint-disable-line
 
   /**
    * @function comparator
@@ -29,19 +29,17 @@ const createComparator = (createIsEqual) => {
       const arrayA = Array.isArray(objectA);
       const arrayB = Array.isArray(objectB);
 
-      let index = 0;
+      let index;
 
       if (arrayA || arrayB) {
         if (arrayA !== arrayB || objectA.length !== objectB.length) {
           return false;
         }
 
-        while (index < objectA.length) {
-          if (!isEqualComparator(objectA[index], objectB[index])) {
+        for (index = 0; index < objectA.length; index++) {
+          if (!isEqual(objectA[index], objectB[index])) {
             return false;
           }
-
-          index++;
         }
 
         return true;
@@ -67,8 +65,11 @@ const createComparator = (createIsEqual) => {
         );
       }
 
-      if (isFunction(objectA.forEach)) {
-        if (!isFunction(objectB.forEach)) {
+      const iterableA = typeof objectA.forEach === 'function';
+      const iterableB = typeof objectB.forEach === 'function';
+
+      if (iterableA || iterableB) {
+        if (iterableA !== iterableB || objectA.size !== objectB.size) {
           return false;
         }
 
@@ -84,22 +85,20 @@ const createComparator = (createIsEqual) => {
         return false;
       }
 
-      let keyA;
+      let key;
 
-      while (index < keysA.length) {
-        keyA = keysA[index];
+      for (index = 0; index < keysA.length; index++) {
+        key = keysA[index];
 
-        if (!Object.prototype.hasOwnProperty.call(objectB, keyA) || !isEqualComparator(objectA[keyA], objectB[keyA])) {
+        if (!Object.prototype.hasOwnProperty.call(objectB, key) || !isEqual(objectA[key], objectB[key])) {
           return false;
         }
-
-        index++;
       }
 
       return true;
     }
 
-    return isNAN(objectA) && isNAN(objectB);
+    return objectA !== objectA && objectB !== objectB;
   }
 
   return comparator;

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,32 +15,6 @@ export const createIsStrictlyEqual = () => {
 };
 
 /**
- * @function isFunction
- *
- * @description
- * is the object passed a function
- *
- * @param {*} object the object to test
- * @returns {boolean} is the value a function
- */
-export const isFunction = (object) => {
-  return typeof object === 'function';
-};
-
-/**
- * @function isNAN
- *
- * @description
- * is the object passed NaN
- *
- * @param {*} object the object to test
- * @returns {boolean} is the object NaN
- */
-export const isNAN = (object) => {
-  return object !== object;
-};
-
-/**
  * @function toPairs
  *
  * @param {Map|Set} iterable the iterable to convert to [key, value] pairs (entries)

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,18 +5,6 @@ import {alternativeValues, mainValues} from 'test/helpers/dataTypes';
 // src
 import * as utils from 'src/utils';
 
-test('if isFunction will return true for a function, false otherwise', (t) => {
-  Object.keys(mainValues).forEach((key) => {
-    t[key === 'fn'](utils.isFunction(mainValues[key]));
-  });
-});
-
-test('if isNAN will return true for a NaN, false otherwise', (t) => {
-  Object.keys(mainValues).forEach((key) => {
-    t[key === 'nan'](utils.isNAN(mainValues[key]));
-  });
-});
-
 test('if createIsStrictlyEqual will return true when strictly equal, false otherwise', (t) => {
   Object.keys(mainValues).forEach((key) => {
     t[key !== 'nan'](utils.createIsStrictlyEqual()(mainValues[key], mainValues[key]), `${key} - true`);


### PR DESCRIPTION
Also reduce footprint (and improve performance) by eliminating utilities for isNAN and isFunction in favor of runtime checks for self-equaility and typeof.