### PR TITLE
Make map and set support explicit

### DIFF
--- a/src/comparator.js
+++ b/src/comparator.js
@@ -1,5 +1,5 @@
 // utils
-import {areIterablesEqual, toPairs} from './utils';
+import {areIterablesEqual} from './utils';
 
 const HAS_MAP_SUPPORT = typeof Map === 'function';
 const HAS_SET_SUPPORT = typeof Set === 'function';

--- a/src/comparator.js
+++ b/src/comparator.js
@@ -1,5 +1,8 @@
 // utils
-import {toPairs} from './utils';
+import {areIterablesEqual, toPairs} from './utils';
+
+const HAS_MAP_SUPPORT = typeof Map === 'function';
+const HAS_SET_SUPPORT = typeof Set === 'function';
 
 const createComparator = (createIsEqual) => {
   const isEqual = typeof createIsEqual === 'function' ? createIsEqual(comparator) : comparator; // eslint-disable-line
@@ -65,18 +68,22 @@ const createComparator = (createIsEqual) => {
         );
       }
 
-      const iterableA = typeof objectA.forEach === 'function';
-      const iterableB = typeof objectB.forEach === 'function';
+      if (HAS_MAP_SUPPORT) {
+        const mapA = objectA instanceof Map;
+        const mapB = objectB instanceof Map;
 
-      if (iterableA || iterableB) {
-        if (iterableA !== iterableB || objectA.size !== objectB.size) {
-          return false;
+        if (mapA || mapB) {
+          return mapA === mapB && areIterablesEqual(objectA, objectB, comparator);
         }
+      }
 
-        const pairsA = toPairs(objectA);
-        const pairsB = toPairs(objectB);
+      if (HAS_SET_SUPPORT) {
+        const setA = objectA instanceof Set;
+        const setB = objectB instanceof Set;
 
-        return comparator(pairsA.keys, pairsB.keys) && comparator(pairsA.values, pairsB.values);
+        if (setA || setB) {
+          return setA === setB && areIterablesEqual(objectA, objectB, comparator);
+        }
       }
 
       const keysA = Object.keys(objectA);

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,6 +34,17 @@ export const toPairs = (iterable) => {
   return pairs;
 };
 
+/**
+ * @function areIterablesEqual
+ *
+ * @description
+ * determine if the iterables are equivalent in value
+ *
+ * @param {Map|Set} objectA the object to test
+ * @param {Map|Set} objectB the object to test against
+ * @param {function} comparator the comparator to determine deep equality
+ * @returns {boolean} are the objects equal in value
+ */
 export const areIterablesEqual = (objectA, objectB, comparator) => {
   if (objectA.size !== objectB.size) {
     return false;

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,3 +33,13 @@ export const toPairs = (iterable) => {
 
   return pairs;
 };
+
+export const areIterablesEqual = (objectA, objectB, comparator) => {
+  if (objectA.size !== objectB.size) {
+    return false;
+  }
+  const pairsA = toPairs(objectA);
+  const pairsB = toPairs(objectB);
+
+  return comparator(pairsA.keys, pairsB.keys) && comparator(pairsA.values, pairsB.values);
+};

--- a/test/helpers/testSuites.js
+++ b/test/helpers/testSuites.js
@@ -393,6 +393,13 @@ module.exports = [
         value2: {foo: 'bar'},
         deepEqual: false,
         shallowEqual: false
+      },
+      {
+        description: 'Map and Set are not equal',
+        value1: new Map().set('foo', 'foo'),
+        value2: new Set().add('foo'),
+        deepEqual: false,
+        shallowEqual: false
       }
     ]
   },

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,6 +5,56 @@ import {alternativeValues, mainValues} from 'test/helpers/dataTypes';
 // src
 import * as utils from 'src/utils';
 
+test('if areIterablesEqual returns false when objects are different sizes', (t) => {
+  const objectA = new Map();
+  const objectB = new Map().set('foo', 'bar');
+  const comparator = (a, b) => {
+    return a === b;
+  };
+
+  t.false(utils.areIterablesEqual(objectA, objectB, comparator));
+});
+
+test('if areIterablesEqual returns false when objects have different keys', (t) => {
+  const objectA = new Map().set('foo', 'bar');
+  const objectB = new Map().set('bar', 'baz');
+  const comparator = (a, b) => {
+    return a === b;
+  };
+
+  t.false(utils.areIterablesEqual(objectA, objectB, comparator));
+});
+
+test('if areIterablesEqual returns false when objects have different values', (t) => {
+  const objectA = new Map().set('foo', 'bar');
+  const objectB = new Map().set('foo', 'baz');
+  const comparator = (a, b) => {
+    return (
+      a.length === b.length &&
+      a.every((value, index) => {
+        return b[index] === value;
+      })
+    );
+  };
+
+  t.false(utils.areIterablesEqual(objectA, objectB, comparator));
+});
+
+test('if areIterablesEqual returns true when objects have the same size, keys, and values', (t) => {
+  const objectA = new Map().set('foo', 'bar');
+  const objectB = new Map().set('foo', 'bar');
+  const comparator = (a, b) => {
+    return (
+      a.length === b.length &&
+      a.every((value, index) => {
+        return b[index] === value;
+      })
+    );
+  };
+
+  t.true(utils.areIterablesEqual(objectA, objectB, comparator));
+});
+
 test('if createIsStrictlyEqual will return true when strictly equal, false otherwise', (t) => {
   Object.keys(mainValues).forEach((key) => {
     t[key !== 'nan'](utils.createIsStrictlyEqual()(mainValues[key], mainValues[key]), `${key} - true`);


### PR DESCRIPTION
* Test explicitly for Map / Set support instead of janky "forEach is a function" check
* Test Map / Set support independently (in case one is polyfilled but not the other)
* Add test to ensure Maps and Sets with equivalent keys + values are not seen as equal (same as an object having index-based keys is not equal to an array with the same values)