### PR TITLE
Improve speed and accuracy of react / object comparison

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "rapid7/browser"
-  ],
+  "extends": ["rapid7/browser"],
   "globals": {
     "__dirname": true,
     "global": true,
@@ -14,5 +12,7 @@
     "ecmaVersion": 6,
     "sourceType": "module"
   },
-  "rules":{}
+  "rules": {
+    "arrow-body-style": [2, "as-needed"]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # fast-equals CHANGELOG
 
+## 1.3.1
+
+* Make `react` comparison more accurate, and a touch faster
+
 ## 1.3.0
 
 * Add support for deep-equal comparisons between `react` elements

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src="https://img.shields.io/badge/coverage-100%25-brightgreen.svg"/>
 <img src="https://img.shields.io/badge/license-MIT-blue.svg"/>
 
-Perform [blazing fast](#benchmarks) equality comparisons (either deep or shallow) on two objects passed. It has no dependencies, and is ~960 bytes when minified and gzipped.
+Perform [blazing fast](#benchmarks) equality comparisons (either deep or shallow) on two objects passed. It has no dependencies, and is ~985 bytes when minified and gzipped.
 
 Unlike most equality validation libraries, the following types are handled out-of-the-box:
 
@@ -148,16 +148,16 @@ All benchmarks are based on averages of running comparisons based on the followi
 
 |                        | Operations / second | Relative margin of error |
 | ---------------------- | ------------------- | ------------------------ |
-| **fast-equals**        | **152,517**         | **0.92%**                |
-| nano-equal             | 108,649             | 1.06%                    |
-| shallow-equal-fuzzy    | 97,115              | 0.85%                    |
-| fast-deep-equal        | 94,622              | 0.91%                    |
-| react-fast-compare     | 94,120              | 0.96%                    |
-| underscore.isEqual     | 62,251              | 0.77%                    |
-| deep-equal             | 29,571              | 0.49%                    |
-| lodash.isEqual         | 25,990              | 0.63%                    |
-| deep-eql               | 16,432              | 0.56%                    |
-| assert.deepStrictEqual | 1,614               | 0.91%                    |
+| **fast-equals**        | **158,904**         | **0.50%**                |
+| nano-equal             | 107,118             | 1.33%                    |
+| fast-deep-equal        | 101,115             | 0.59%                    |
+| shallow-equal-fuzzy    | 100,383             | 0.60%                    |
+| react-fast-compare     | 99,924              | 0.85%                    |
+| underscore.isEqual     | 63,524              | 0.68%                    |
+| deep-equal             | 30,703              | 0.50%                    |
+| lodash.isEqual         | 25,678              | 0.65%                    |
+| deep-eql               | 16,646              | 0.54%                    |
+| assert.deepStrictEqual | 1,583               | 1.04%                    |
 
 Caveats that impact the benchmark (and accuracy of comparison):
 

--- a/src/comparator.js
+++ b/src/comparator.js
@@ -1,5 +1,5 @@
 // utils
-import {areIterablesEqual, createIsSameValueZero} from './utils';
+import {areIterablesEqual, createIsSameValueZero, isReactElement} from './utils';
 
 const HAS_MAP_SUPPORT = typeof Map === 'function';
 const HAS_SET_SUPPORT = typeof Set === 'function';
@@ -99,12 +99,16 @@ const createComparator = (createIsEqual) => {
       for (index = 0; index < keysA.length; index++) {
         key = keysA[index];
 
+        if (!Object.prototype.hasOwnProperty.call(objectB, key)) {
+          return false;
+        }
+
         // if a react element, ignore the "_owner" key because its not necessary for equality comparisons
-        if (key === '_owner' && objectA.$$typeof && objectA._store) {
+        if (key === '_owner' && isReactElement(objectA) && isReactElement(objectB)) {
           continue;
         }
 
-        if (!Object.prototype.hasOwnProperty.call(objectB, key) || !isEqual(objectA[key], objectB[key])) {
+        if (!isEqual(objectA[key], objectB[key])) {
           return false;
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
 // comparator
-import createComparator from './comparator';
+import createCustomEqual from './comparator';
 
 // utils
 import {createIsSameValueZero} from './utils';
 
-export const createCustomEqual = createComparator;
+export {createCustomEqual};
 
-export const deepEqual = createComparator();
+export const deepEqual = createCustomEqual();
 export const sameValueZeroEqual = createIsSameValueZero();
-export const shallowEqual = createComparator(createIsSameValueZero);
+export const shallowEqual = createCustomEqual(createIsSameValueZero);
 
 export default {
   createCustom: createCustomEqual,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-export const createIsSameValueZero = () => {
+export const createIsSameValueZero = () =>
   /**
    * @function isSameValueZero
    *
@@ -9,10 +9,18 @@ export const createIsSameValueZero = () => {
    * @param {*} objectB the object to test
    * @returns {boolean} are the objects equal by the SameValueZero principle
    */
-  return (objectA, objectB) => {
-    return objectA === objectB || (objectA !== objectA && objectB !== objectB);
-  };
-};
+  (objectA, objectB) => objectA === objectB || (objectA !== objectA && objectB !== objectB);
+
+/**
+ * @function isReactElement
+ *
+ * @description
+ * is the object passed a react element
+ *
+ * @param {any} object the object to test
+ * @returns {boolean} is the object a react element
+ */
+export const isReactElement = (object) => !!(object.$$typeof && object._store);
 
 /**
  * @function toPairs

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,7 @@
 // test
 import test from 'ava';
 import {alternativeValues, mainValues} from 'test/helpers/dataTypes';
+import React from 'react';
 
 // src
 import * as utils from 'src/utils';
@@ -8,9 +9,7 @@ import * as utils from 'src/utils';
 test('if areIterablesEqual returns false when objects are different sizes', (t) => {
   const objectA = new Map();
   const objectB = new Map().set('foo', 'bar');
-  const comparator = (a, b) => {
-    return a === b;
-  };
+  const comparator = (a, b) => a === b;
 
   t.false(utils.areIterablesEqual(objectA, objectB, comparator, true));
 });
@@ -18,9 +17,7 @@ test('if areIterablesEqual returns false when objects are different sizes', (t) 
 test('if areIterablesEqual returns false when objects have different keys', (t) => {
   const objectA = new Map().set('foo', 'bar');
   const objectB = new Map().set('bar', 'baz');
-  const comparator = (a, b) => {
-    return a === b;
-  };
+  const comparator = (a, b) => a === b;
 
   t.false(utils.areIterablesEqual(objectA, objectB, comparator, true));
 });
@@ -28,14 +25,7 @@ test('if areIterablesEqual returns false when objects have different keys', (t) 
 test('if areIterablesEqual returns false when objects have different values', (t) => {
   const objectA = new Map().set('foo', 'bar');
   const objectB = new Map().set('foo', 'baz');
-  const comparator = (a, b) => {
-    return (
-      a.length === b.length &&
-      a.every((value, index) => {
-        return b[index] === value;
-      })
-    );
-  };
+  const comparator = (a, b) => a.length === b.length && a.every((value, index) => b[index] === value);
 
   t.false(utils.areIterablesEqual(objectA, objectB, comparator, true));
 });
@@ -43,14 +33,7 @@ test('if areIterablesEqual returns false when objects have different values', (t
 test('if areIterablesEqual returns true when objects have the same size, keys, and values', (t) => {
   const objectA = new Map().set('foo', 'bar');
   const objectB = new Map().set('foo', 'bar');
-  const comparator = (a, b) => {
-    return (
-      a.length === b.length &&
-      a.every((value, index) => {
-        return b[index] === value;
-      })
-    );
-  };
+  const comparator = (a, b) => a.length === b.length && a.every((value, index) => b[index] === value);
 
   t.true(utils.areIterablesEqual(objectA, objectB, comparator, true));
 });
@@ -58,14 +41,7 @@ test('if areIterablesEqual returns true when objects have the same size, keys, a
 test('if areIterablesEqual returns false when objects have the same size but different values when they are sets', (t) => {
   const objectA = new Set().add('foo');
   const objectB = new Set().add('bar');
-  const comparator = (a, b) => {
-    return (
-      a.length === b.length &&
-      a.every((value, index) => {
-        return b[index] === value;
-      })
-    );
-  };
+  const comparator = (a, b) => a.length === b.length && a.every((value, index) => b[index] === value);
 
   t.false(utils.areIterablesEqual(objectA, objectB, comparator, false));
 });
@@ -73,14 +49,7 @@ test('if areIterablesEqual returns false when objects have the same size but dif
 test('if areIterablesEqual returns true when objects have the same size and values when they are sets', (t) => {
   const objectA = new Set().add('bar');
   const objectB = new Set().add('bar');
-  const comparator = (a, b) => {
-    return (
-      a.length === b.length &&
-      a.every((value, index) => {
-        return b[index] === value;
-      })
-    );
-  };
+  const comparator = (a, b) => a.length === b.length && a.every((value, index) => b[index] === value);
 
   t.true(utils.areIterablesEqual(objectA, objectB, comparator, false));
 });
@@ -93,6 +62,20 @@ test('if createIsSameValueZero will return true when strictly equal or NaN, fals
       t.false(utils.createIsSameValueZero()(mainValues[key], alternativeValues[key]), `${key} - false`);
     }
   });
+});
+
+test('if isCircularReactElement will return true if the appropriate keys are present and truthy', (t) => {
+  const div = React.createElement('div', {children: 'foo'});
+
+  t.true(utils.isReactElement(div));
+});
+
+test('if isCircularReactElement will return false if the appropriate keys are not present and truthy', (t) => {
+  const div = {
+    foo: 'bar'
+  };
+
+  t.false(utils.isReactElement(div));
 });
 
 test('if toPairs will convert the map into {keys: [], values: []} pairs', (t) => {

--- a/yarn-error.log
+++ b/yarn-error.log
@@ -19,9 +19,15 @@ npm manifest:
     "ava": {
       "babel": "inherit",
       "failFast": true,
-      "files": ["test/*.js"],
-      "require": ["babel-register"],
-      "source": ["src/*.js"],
+      "files": [
+        "test/*.js"
+      ],
+      "require": [
+        "babel-register"
+      ],
+      "source": [
+        "src/*.js"
+      ],
       "verbose": true
     },
     "bugs": {
@@ -67,7 +73,13 @@ npm manifest:
       "webpack-dev-server": "^3.1.3"
     },
     "homepage": "https://github.com/planttheidea/fast-equals#readme",
-    "keywords": ["fast", "equal", "equals", "deep-equal", "equivalent"],
+    "keywords": [
+      "fast",
+      "equal",
+      "equals",
+      "deep-equal",
+      "equivalent"
+    ],
     "license": "MIT",
     "main": "lib/index.js",
     "types": "index.d.ts",
@@ -89,8 +101,7 @@ npm manifest:
       "lint": "NODE_ENV=test eslint src --max-warnings 0",
       "lint:fix": "NODE_ENV=test eslint src --fix",
       "prepublish": "if in-publish; then npm run prepublish:compile; fi",
-      "prepublish:compile":
-        "npm run lint && npm run test:coverage && npm run transpile:lib && npm run transpile:es && npm run dist",
+      "prepublish:compile": "npm run lint && npm run test:coverage && npm run transpile:lib && npm run transpile:es && npm run dist",
       "start": "npm run dev",
       "test": "NODE_PATH=. BABEL_ENV=test ava",
       "test:coverage": "nyc npm test",
@@ -98,7 +109,7 @@ npm manifest:
       "transpile:es": "npm run clean:es && BABEL_ENV=es babel src --out-dir es",
       "transpile:lib": "npm run clean:lib && BABEL_ENV=lib babel src --out-dir lib"
     },
-    "version": "1.2.1"
+    "version": "1.3.0"
   }
 
 yarn manifest: 


### PR DESCRIPTION
* Move the "react element" test to a standalone utility
* Ensure both objects are react elements before foregoing equality check
* Improve order of operations for object key equality check