### PR TITLE
Ignore rollup plugin cache when publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 .gitignore
 .idea
 .nyc_output
+.rpt2_cache
 .yarnrc
 __tests__
 benchmark


### PR DESCRIPTION
Some cache files are being published rollup build, which can cause problems with caching routines on some CI environments.
I'm currently having problems to cache `node_modules` on Github Actions because of them.

![image](https://user-images.githubusercontent.com/5903869/113752958-ee054f00-96e3-11eb-9fb0-659e2513d905.png)
