### PR TITLE
Fix is cacheable check typo

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,7 +115,7 @@ export function createCircularEqualCreator(isEqual?: EqualityComparator) {
           cache.add(a);
         }
 
-        if (isCacheableA) {
+        if (isCacheableB) {
           cache.add(b);
         }
       }


### PR DESCRIPTION
Fix the is cacheable check when adding `b` to the cache. Looks like it was just a simple typo.