### PR TITLE
Issue 77 - circular reference naivete

### DIFF
--- a/DEV_ONLY/index.tsx
+++ b/DEV_ONLY/index.tsx
@@ -251,15 +251,15 @@ const cache = new WeakMap();
 
 const isDeepEqualCircular = createCustomEqual((comparator) => (a, b) => {
   if (cache.has(a) || cache.has(b)) {
-    return cache.has(a) && cache.has(b);
+    return cache.get(a) === cache.get(b);
   }
 
   if (typeof a === 'object') {
-    cache.add(a);
+    cache.set(a, b);
   }
 
   if (typeof b === 'object') {
-    cache.add(b);
+    cache.set(b, a);
   }
 
   return comparator(a, b);

--- a/DEV_ONLY/index.tsx
+++ b/DEV_ONLY/index.tsx
@@ -247,7 +247,7 @@ console.groupEnd();
 
 console.group('circular object');
 
-const cache = new WeakSet();
+const cache = new WeakMap();
 
 const isDeepEqualCircular = createCustomEqual((comparator) => (a, b) => {
   if (cache.has(a) || cache.has(b)) {

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -111,6 +111,15 @@ describe('circularDeepEqual', () => {
       false,
     );
   });
+
+  it('should handle shared references between objects', () => {
+    const x = [1]
+    const left =  [{ a: [1], b:  x  }]
+    const right = [{ a:  x,  b: [1] }]
+
+    // should returns true, but returns false
+    expect(circularDeepEqual( left, right )).toBe(true);
+  });
 });
 
 describe('circularShallowEqual', () => {

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -28,14 +28,14 @@ describe('areArraysEqual', () => {
   it('should return false when the arrays are different lengths', () => {
     const a = ['foo', 'bar'];
     const b = ['foo', 'bar', 'baz'];
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areArraysEqual(a, b, sameValueZeroEqual, cache)).toBe(false);
   });
 
   it('should return false when the arrays are not equal in value', () => {
     const a = ['foo', 'bar'];
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     const b = ['foo', 'baz'];
     expect(areArraysEqual(a, b, sameValueZeroEqual, cache)).toBe(false);
@@ -44,7 +44,7 @@ describe('areArraysEqual', () => {
   it('should return true when the arrays are equal in value', () => {
     const a = ['foo', 'bar'];
     const b = ['foo', 'bar'];
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areArraysEqual(a, b, sameValueZeroEqual, cache)).toBe(true);
   });
@@ -54,7 +54,7 @@ describe('areMapsEqual', () => {
   it('should return false when maps are different sizes', () => {
     const a = new Map();
     const b = new Map().set('foo', 'bar');
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areMapsEqual(a, b, sameValueZeroEqual, cache)).toBe(false);
   });
@@ -62,7 +62,7 @@ describe('areMapsEqual', () => {
   it('should return false when maps have different keys', () => {
     const a = new Map().set('foo', 'bar');
     const b = new Map().set('bar', 'bar');
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areMapsEqual(a, b, sameValueZeroEqual, cache)).toBe(false);
   });
@@ -70,7 +70,7 @@ describe('areMapsEqual', () => {
   it('should return false when maps have different values', () => {
     const a = new Map().set('foo', 'bar');
     const b = new Map().set('foo', 'baz');
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areMapsEqual(a, b, sameValueZeroEqual, cache)).toBe(false);
   });
@@ -78,7 +78,7 @@ describe('areMapsEqual', () => {
   it('should return true when maps have the same size, keys, and values', () => {
     const a = new Map().set('foo', 'bar');
     const b = new Map().set('foo', 'bar');
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areMapsEqual(a, b, sameValueZeroEqual, cache)).toBe(true);
   });
@@ -86,7 +86,7 @@ describe('areMapsEqual', () => {
   it('should return true when maps have the same size, keys, and values regardless of order', () => {
     const a = new Map().set('bar', 'foo').set('foo', 'bar');
     const b = new Map().set('foo', 'bar').set('bar', 'foo');
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areMapsEqual(a, b, sameValueZeroEqual, cache)).toBe(true);
   });
@@ -148,7 +148,7 @@ describe('areMapsEqual', () => {
       (_, aEntries: any[], bEntries: any[], expected) => {
         const mapA = new Map<any, any>(aEntries);
         const mapB = new Map<any, any>(bEntries);
-        const cache = new WeakSet();
+        const cache = new WeakMap();
 
         expect(areMapsEqual(mapA, mapB, deepEqual, cache)).toBe(expected);
         expect(areMapsEqual(mapB, mapA, deepEqual, cache)).toBe(expected);
@@ -161,7 +161,7 @@ describe('areObjectsEqual', () => {
   it('should return false when the objects have different key lengths', () => {
     const a = { bar: 'bar', foo: 'foo' };
     const b = { bar: 'bar', baz: 'baz', foo: 'foo' };
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areObjectsEqual(a, b, sameValueZeroEqual, cache)).toBe(false);
   });
@@ -169,7 +169,7 @@ describe('areObjectsEqual', () => {
   it('should return false when the objects have different keys', () => {
     const a = { bar: 'bar', foo: 'foo' };
     const b = { baz: 'bar', foo: 'foo' };
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areObjectsEqual(a, b, sameValueZeroEqual, cache)).toBe(false);
   });
@@ -177,7 +177,7 @@ describe('areObjectsEqual', () => {
   it('should return false when the objects are not equal in value', () => {
     const a = { bar: 'bar', foo: 'foo' };
     const b = { bar: 'baz', foo: 'foo' };
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areObjectsEqual(a, b, sameValueZeroEqual, cache)).toBe(false);
   });
@@ -185,7 +185,7 @@ describe('areObjectsEqual', () => {
   it('should return true when the objects are equal in value', () => {
     const a = { bar: 'bar', foo: 'foo' };
     const b = { bar: 'bar', foo: 'foo' };
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areObjectsEqual(a, b, sameValueZeroEqual, cache)).toBe(true);
   });
@@ -246,7 +246,7 @@ describe('areSetsEqual', () => {
   it('should return false when the sets have different sizes', () => {
     const a = new Set().add('foo').add('bar');
     const b = new Set().add('bar');
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areSetsEqual(a, b, sameValueZeroEqual, cache)).toBe(false);
   });
@@ -254,7 +254,7 @@ describe('areSetsEqual', () => {
   it('should return false when the sets have different values', () => {
     const a = new Set().add('foo');
     const b = new Set().add('bar');
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areSetsEqual(a, b, sameValueZeroEqual, cache)).toBe(false);
   });
@@ -262,7 +262,7 @@ describe('areSetsEqual', () => {
   it('should return true when the sets have the same values', () => {
     const a = new Set().add('foo');
     const b = new Set().add('foo');
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areSetsEqual(a, b, sameValueZeroEqual, cache)).toBe(true);
   });
@@ -270,7 +270,7 @@ describe('areSetsEqual', () => {
   it('should return true when the sets have the same values regardless of order', () => {
     const a = new Set().add('foo').add('bar');
     const b = new Set().add('bar').add('foo');
-    const cache = new WeakSet();
+    const cache = new WeakMap();
 
     expect(areSetsEqual(a, b, sameValueZeroEqual, cache)).toBe(true);
   });
@@ -304,7 +304,7 @@ describe('areSetsEqual', () => {
     ])('should handle `Set` entries %s', (_, aEntries, bEntries, expected) => {
       const setA = new Set<any>(aEntries);
       const setB = new Set<any>(bEntries);
-      const cache = new WeakSet();
+      const cache = new WeakMap();
 
       expect(areSetsEqual(setA, setB, deepEqual, cache)).toBe(expected);
       expect(areSetsEqual(setB, setA, deepEqual, cache)).toBe(expected);
@@ -313,22 +313,28 @@ describe('areSetsEqual', () => {
 });
 
 describe('createCircularEqualCreator', () => {
-  it('should create the custom comparator that stores the values in cache', () => {
-    const ws = global.WeakSet;
+  it('should create the custom comparator that stores the values in fallback cache', () => {
+    const wm = global.WeakMap;
 
-    const values: any[] = [];
+    const entries: any[] = [];
 
-    const add = jest.fn().mockImplementation((object) => values.push(object));
-    const has = jest
-      .fn()
-      .mockImplementation((object) => values.indexOf(object) !== -1);
+    const del = jest.fn((key) => {
+      const index = entries.findIndex((entry) => entry[0] === key);
+
+      if (index === -1) {
+        entries.splice(index, 1);
+      }
+    });
+    const get = jest.fn((key) => entries.find((entry) => entry[0] === key))
+    const set = jest.fn((key, value) => entries.push([key, value]));
 
     // @ts-ignore
-    global.WeakSet = function WeakSet() {
-      this._values = values;
+    global.WeakMap = function WeakMap() {
+      this._entries = entries;
 
-      this.add = add;
-      this.has = has;
+      this.delete = del;
+      this.get = get;
+      this.set = set;
     };
 
     const handler = createCircularEqualCreator(undefined);
@@ -342,51 +348,42 @@ describe('createCircularEqualCreator', () => {
 
     const result = internalComparator(a, a, undefined, undefined, undefined, undefined, undefined);
 
-    expect(has).toHaveBeenCalledTimes(2);
-    expect(has).toHaveBeenNthCalledWith(1, a);
-    expect(has).toHaveBeenNthCalledWith(2, b);
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith(a);
 
-    has.mockClear();
+    get.mockClear();
 
-    expect(add).toHaveBeenCalledTimes(2);
-    expect(add).toHaveBeenNthCalledWith(1, a);
-    expect(add).toHaveBeenNthCalledWith(2, b);
+    expect(set).toHaveBeenCalledTimes(2);
+    expect(set).toHaveBeenNthCalledWith(1, a, b);
+    expect(set).toHaveBeenNthCalledWith(2, b, a);
 
-    add.mockClear();
+    set.mockClear();
 
     expect(result).toBe(true);
 
-    internalComparator(a, b, undefined, undefined, undefined, undefined, undefined);
-
-    expect(has).toHaveBeenCalledTimes(2);
-    expect(has).toHaveBeenNthCalledWith(1, a);
-    expect(has).toHaveBeenNthCalledWith(2, b);
-
-    expect(add).not.toHaveBeenCalled();
-
-    global.WeakSet = ws;
+    global.WeakMap = wm;
   });
 });
 
 describe('getNewCache', () => {
-  it('should return a new WeakSet when support is present', () => {
+  it('should return a new WeakMap when support is present', () => {
     const cache = getNewCache();
 
-    expect(cache).toBeInstanceOf(WeakSet);
+    expect(cache).toBeInstanceOf(WeakMap);
   });
 
-  it('should work the same with the fallback when WeakSet is not supported', () => {
+  it('should work the same with the fallback when WeakMap is not supported', () => {
     const cache = getNewCacheFallback();
 
-    expect(cache).not.toBeInstanceOf(WeakSet);
+    expect(cache).not.toBeInstanceOf(WeakMap);
 
     const value = { foo: 'bar' };
 
-    expect(cache.has(value)).toBe(false);
+    expect(cache.get(value)).toBe(undefined);
 
-    cache.add(value);
+    cache.set(value, value);
 
-    expect(cache.has(value)).toBe(true);
+    expect(cache.get(value)).toBe(value);
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,11 +91,11 @@ export function getNewCacheFallback(): Cache {
  * @returns the new cache object
  */
 export const getNewCache = ((canUseWeakMap: boolean) => {
-  // if (canUseWeakMap) {
-  //   return function _getNewCache(): Cache {
-  //     return new WeakMap();
-  //   };
-  // }
+  if (canUseWeakMap) {
+    return function _getNewCache(): Cache {
+      return new WeakMap();
+    };
+  }
 
   return getNewCacheFallback;
 })(HAS_WEAK_MAP_SUPPORT);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,12 @@
 import type { EqualityComparator, InternalEqualityComparator } from './types';
 
 interface Cache {
-  add: (value: any) => void;
-  has: (value: any) => boolean;
+  delete: (key: object) => void;
+  get: (key: object) => object | undefined;
+  set: (key: object, value: object) => void;
 }
 
-const HAS_WEAKSET_SUPPORT = typeof WeakSet === 'function';
+const HAS_WEAK_MAP_SUPPORT = typeof WeakMap === 'function';
 
 const { keys } = Object;
 
@@ -57,16 +58,30 @@ export function isReactElement(value: any) {
  * @returns the new cache object
  */
 export function getNewCacheFallback(): Cache {
-  const values: any[] = [];
+  const entries: [object, object][] = [];
 
   return {
-    add(value: any) {
-      values.push(value);
+    delete(key: object) {
+      for (let index = 0; index < entries.length; ++index) {
+        if (entries[index][0] === key) {
+          entries.splice(index, 1);
+          return;
+        }
+      }
     },
 
-    has(value: any) {
-      return values.indexOf(value) !== -1;
+    get(key: object) {
+      console.log(key);
+      for (let index = 0; index < entries.length; ++index) {
+        if (entries[index][0] === key) {
+          return entries[index][1];
+        }
+      }
     },
+
+    set(key: object, value: object) {
+      entries.push([key, value])
+    }
   };
 }
 
@@ -76,14 +91,14 @@ export function getNewCacheFallback(): Cache {
  * @returns the new cache object
  */
 export const getNewCache = ((canUseWeakMap: boolean) => {
-  if (canUseWeakMap) {
-    return function _getNewCache(): Cache {
-      return new WeakSet();
-    };
-  }
+  // if (canUseWeakMap) {
+  //   return function _getNewCache(): Cache {
+  //     return new WeakMap();
+  //   };
+  // }
 
   return getNewCacheFallback;
-})(HAS_WEAKSET_SUPPORT);
+})(HAS_WEAK_MAP_SUPPORT);
 
 /**
  * create a custom isEqual handler specific to circular objects
@@ -109,24 +124,29 @@ export function createCircularEqualCreator(isEqual?: EqualityComparator) {
       const isCacheableA = !!a && typeof a === 'object';
       const isCacheableB = !!b && typeof b === 'object';
 
-      if (isCacheableA || isCacheableB) {
-        const hasA = isCacheableA && cache.has(a);
-        const hasB = isCacheableB && cache.has(b);
-
-        if (hasA || hasB) {
-          return hasA && hasB;
-        }
-
-        if (isCacheableA) {
-          cache.add(a);
-        }
-
-        if (isCacheableB) {
-          cache.add(b);
-        }
+      if (isCacheableA !== isCacheableB) {
+        return false;
       }
 
-      return _comparator(a, b, cache);
+      if (!isCacheableA && !isCacheableB) {
+        return _comparator(a, b, cache);
+      }
+
+      const cachedA = cache.get(a);
+      
+      if(cachedA && cache.get(b)) {
+        return cachedA === b;
+      }
+
+      cache.set(a, b);
+      cache.set(b, a);
+
+      const result = _comparator(a, b, cache);
+
+      cache.delete(a);
+      cache.delete(b);
+
+      return result;
     };
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,7 @@ export function isReactElement(value: any) {
 }
 
 /**
- * in cases where WeakSet is not supported, creates a new custom
+ * in cases where WeakMap is not supported, creates a new custom
  * object that mimics the necessary API aspects for cache purposes
  *
  * @returns the new cache object

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,6 @@ export function getNewCacheFallback(): Cache {
     },
 
     get(key: object) {
-      console.log(key);
       for (let index = 0; index < entries.length; ++index) {
         if (entries[index][0] === key) {
           return entries[index][1];
@@ -80,7 +79,14 @@ export function getNewCacheFallback(): Cache {
     },
 
     set(key: object, value: object) {
-      entries.push([key, value])
+      for (let index = 0; index < entries.length; ++index) {
+        if (entries[index][0] === key) {
+          entries[index][1] = value;
+          return;
+        }
+      }
+
+      entries.push([key, value]);
     }
   };
 }


### PR DESCRIPTION
## Reason for change

Checking of already-compared circular objects was naive, creating false inequality comparisons. See #77 for more details.

## Change

Convert cache from `WeakSet` to `WeakMap` setup, and make the checks more targeted to the specific comparison. Inspiration was taken from [how `lodash` handles their circular reference checks](https://github.com/lodash/lodash/blob/master/.internal/equalObjects.js#L40).

Resolves #77 