### PR TITLE
Export explicit types to allow use of `export type`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,23 @@
 import type { CustomEqualCreatorOptions } from './src/internalTypes';
 
-export * from './src/internalTypes';
+export type {
+  AnyEqualityComparator,
+  Cache,
+  CircularState,
+  ComparatorConfig,
+  CreateCustomComparatorConfig,
+  CreateState,
+  CustomEqualCreatorOptions,
+  DefaultState,
+  Dictionary,
+  EqualityComparator,
+  EqualityComparatorCreator,
+  InternalEqualityComparator,
+  PrimitiveWrapper,
+  State,
+  TypeEqualityComparator,
+  TypedArray,
+} from './src/internalTypes';
 
 /**
  * Whether the values passed are strictly equal or both NaN.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,24 @@ import type { CustomEqualCreatorOptions } from './internalTypes';
 import { sameValueZeroEqual } from './utils';
 
 export { sameValueZeroEqual };
-export * from './internalTypes';
+export type {
+  AnyEqualityComparator,
+  Cache,
+  CircularState,
+  ComparatorConfig,
+  CreateCustomComparatorConfig,
+  CreateState,
+  CustomEqualCreatorOptions,
+  DefaultState,
+  Dictionary,
+  EqualityComparator,
+  EqualityComparatorCreator,
+  InternalEqualityComparator,
+  PrimitiveWrapper,
+  State,
+  TypeEqualityComparator,
+  TypedArray,
+} from './internalTypes';
 
 /**
  * Whether the items passed are deeply-equal in value.


### PR DESCRIPTION
Should resolve #114 