### PR TITLE
[Iterables] Speed improvement

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -81,6 +81,10 @@ for (const name in packages) {
   for (const testSuite of tests) {
     const { description } = testSuite;
 
+    if (description !== 'maps' && description !== 'sets') {
+      continue;
+    }
+
     if (!typesBenches[description]) {
       typesBenches[description] = new Bench({ iterations });
     }

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -81,10 +81,6 @@ for (const name in packages) {
   for (const testSuite of tests) {
     const { description } = testSuite;
 
-    if (description !== 'maps' && description !== 'sets') {
-      continue;
-    }
-
     if (!typesBenches[description]) {
       typesBenches[description] = new Bench({ iterations });
     }

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -79,11 +79,17 @@ for (const name in packages) {
   }
 
   for (const testSuite of tests) {
-    if (!typesBenches[testSuite.description]) {
-      typesBenches[testSuite.description] = new Bench({ iterations });
+    const { description } = testSuite;
+
+    if (description !== 'maps' && description !== 'sets') {
+      continue;
     }
 
-    const typesBench = typesBenches[testSuite.description];
+    if (!typesBenches[description]) {
+      typesBenches[description] = new Bench({ iterations });
+    }
+
+    const typesBench = typesBenches[description];
 
     typesBench.add(
       `${name} (${

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -81,7 +81,6 @@ export function areMapsEqual(
 
   let aResult: IteratorResult<[any, any]>;
   let bResult: IteratorResult<[any, any]>;
-  let matchIndex: number;
   let index = 0;
 
   while ((aResult = aIterable.next())) {
@@ -92,16 +91,15 @@ export function areMapsEqual(
     const bIterable = b.entries();
 
     let hasMatch = false;
-    let nextMatchIndex = (matchIndex = 0);
+    let matchIndex = 0;
 
     while ((bResult = bIterable.next())) {
       if (bResult.done) {
         break;
       }
 
-      matchIndex = nextMatchIndex++;
-
       if (matchedIndices[matchIndex]) {
+        matchIndex++;
         continue;
       }
 
@@ -115,6 +113,8 @@ export function areMapsEqual(
         hasMatch = matchedIndices[matchIndex] = true;
         break;
       }
+
+      matchIndex++;
     }
 
     if (!hasMatch) {

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -66,16 +66,23 @@ export function areMapsEqual(
   b: Map<any, any>,
   state: State<any>,
 ): boolean {
-  if (a.size !== b.size) {
+  const size = a.size;
+
+  if (size !== b.size) {
     return false;
   }
 
-  const matchedIndices: Array<true | undefined> = new Array(b.size);
+  if (!size) {
+    return true;
+  }
+
+  const matchedIndices: Array<true | undefined> = new Array(size);
   const aIterable = a.entries();
 
-  let index = 0;
   let aResult: IteratorResult<[any, any]>;
   let bResult: IteratorResult<[any, any]>;
+  let matchIndex: number;
+  let index = 0;
 
   while ((aResult = aIterable.next())) {
     if (aResult.done) {
@@ -85,15 +92,16 @@ export function areMapsEqual(
     const bIterable = b.entries();
 
     let hasMatch = false;
-    let matchIndex = 0;
+    let nextMatchIndex = (matchIndex = 0);
 
     while ((bResult = bIterable.next())) {
       if (bResult.done) {
         break;
       }
 
+      matchIndex = nextMatchIndex++;
+
       if (matchedIndices[matchIndex]) {
-        matchIndex++;
         continue;
       }
 
@@ -107,8 +115,6 @@ export function areMapsEqual(
         hasMatch = matchedIndices[matchIndex] = true;
         break;
       }
-
-      matchIndex++;
     }
 
     if (!hasMatch) {
@@ -258,11 +264,17 @@ export function areSetsEqual(
   b: Set<any>,
   state: State<any>,
 ): boolean {
-  if (a.size !== b.size) {
+  const size = a.size;
+
+  if (size !== b.size) {
     return false;
   }
 
-  const matchedIndices: Array<true | undefined> = new Array(b.size);
+  if (!size) {
+    return true;
+  }
+
+  const matchedIndices: Array<true | undefined> = new Array(size);
   const aIterable = a.values();
 
   let aResult: IteratorResult<any>;

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -88,7 +88,7 @@ export function areMapsEqual(
     let matchIndex = 0;
 
     while ((bResult = bIterable.next())) {
-      if (bResult.done || hasMatch) {
+      if (bResult.done) {
         break;
       }
 
@@ -105,6 +105,7 @@ export function areMapsEqual(
         state.equals(aEntry[1], bEntry[1], aEntry[0], bEntry[0], a, b, state)
       ) {
         hasMatch = matchedIndices[matchIndex] = true;
+        break;
       }
 
       matchIndex++;
@@ -278,7 +279,7 @@ export function areSetsEqual(
     let matchIndex = 0;
 
     while ((bResult = bIterable.next())) {
-      if (bResult.done || hasMatch) {
+      if (bResult.done) {
         break;
       }
 
@@ -295,6 +296,7 @@ export function areSetsEqual(
         )
       ) {
         hasMatch = matchedIndices[matchIndex] = true;
+        break;
       }
 
       matchIndex++;

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -70,7 +70,7 @@ export function areMapsEqual(
     return false;
   }
 
-  const matchedIndices: Record<number, true> = {};
+  const matchedIndices: Array<true | undefined> = new Array(b.size);
   const aIterable = a.entries();
 
   let index = 0;
@@ -101,11 +101,10 @@ export function areMapsEqual(
       const bEntry = bResult.value;
 
       if (
-        (hasMatch =
-          state.equals(aEntry[0], bEntry[0], index, matchIndex, a, b, state) &&
-          state.equals(aEntry[1], bEntry[1], aEntry[0], bEntry[0], a, b, state))
+        state.equals(aEntry[0], bEntry[0], index, matchIndex, a, b, state) &&
+        state.equals(aEntry[1], bEntry[1], aEntry[0], bEntry[0], a, b, state)
       ) {
-        matchedIndices[matchIndex] = true;
+        hasMatch = matchedIndices[matchIndex] = true;
       }
 
       matchIndex++;
@@ -262,7 +261,7 @@ export function areSetsEqual(
     return false;
   }
 
-  const matchedIndices: Record<number, true> = {};
+  const matchedIndices: Array<true | undefined> = new Array(b.size);
   const aIterable = a.values();
 
   let aResult: IteratorResult<any>;
@@ -283,13 +282,9 @@ export function areSetsEqual(
         break;
       }
 
-      if (matchedIndices[matchIndex]) {
-        matchIndex++;
-        continue;
-      }
-
       if (
-        (hasMatch = state.equals(
+        !matchedIndices[matchIndex] &&
+        state.equals(
           aResult.value,
           bResult.value,
           aResult.value,
@@ -297,9 +292,9 @@ export function areSetsEqual(
           a,
           b,
           state,
-        ))
+        )
       ) {
-        matchedIndices[matchIndex] = true;
+        hasMatch = matchedIndices[matchIndex] = true;
       }
 
       matchIndex++;

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -88,19 +88,22 @@ export function areMapsEqual(
     let matchIndex = 0;
 
     while ((bResult = bIterable.next())) {
-      if (bResult.done) {
+      if (bResult.done || hasMatch) {
         break;
       }
 
-      const [aKey, aValue] = aResult.value;
-      const [bKey, bValue] = bResult.value;
+      if (matchedIndices[matchIndex]) {
+        matchIndex++;
+        continue;
+      }
+
+      const aEntry = aResult.value;
+      const bEntry = bResult.value;
 
       if (
-        !hasMatch &&
-        !matchedIndices[matchIndex] &&
         (hasMatch =
-          state.equals(aKey, bKey, index, matchIndex, a, b, state) &&
-          state.equals(aValue, bValue, aKey, bKey, a, b, state))
+          state.equals(aEntry[0], bEntry[0], index, matchIndex, a, b, state) &&
+          state.equals(aEntry[1], bEntry[1], aEntry[0], bEntry[0], a, b, state))
       ) {
         matchedIndices[matchIndex] = true;
       }
@@ -276,13 +279,16 @@ export function areSetsEqual(
     let matchIndex = 0;
 
     while ((bResult = bIterable.next())) {
-      if (bResult.done) {
+      if (bResult.done || hasMatch) {
         break;
       }
 
+      if (matchedIndices[matchIndex]) {
+        matchIndex++;
+        continue;
+      }
+
       if (
-        !hasMatch &&
-        !matchedIndices[matchIndex] &&
         (hasMatch = state.equals(
           aResult.value,
           bResult.value,


### PR DESCRIPTION
Main changes are to bail out early when a match has been found and use a pre-sized array instead of an object for the matched index cache.

Maps - 100.7% improvement
Sets - 127.28% improvement