### PR TITLE
[React] Fix owner comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # fast-equals CHANGELOG
 
+## 5.1.4
+
+### Enhancements
+
+- Support Preact objects in equality comparison
+
+### Bugfixes
+
+- [#137](https://github.com/planttheidea/fast-equals/pull/137) - Fix circular React references in object comparisons
+
 ## 5.1.3
 
 ### Enhancements

--- a/__tests__/__helpers__/testSuites.js
+++ b/__tests__/__helpers__/testSuites.js
@@ -4,6 +4,19 @@ import React from 'react';
 const fn = () => {};
 const promise = Promise.resolve('foo');
 
+const reactElementA = { ...React.createElement('div', { x: 1 }) };
+// in reality the _owner object is much more complex (and contains over dozen circular references)
+reactElementA._owner = { children: [reactElementA] };
+
+const reactElementA2 = { ...React.createElement('div', { x: 1 }) };
+reactElementA2._owner = { children: [reactElementA2] };
+
+const reactElementB = { ...React.createElement('div', { x: 2 }) };
+reactElementB._owner = { children: [reactElementB] };
+
+const reactElementC = { ...React.createElement('span', { x: 1 }) };
+reactElementC._owner = { children: [reactElementC] };
+
 export default [
   {
     description: 'primitives',
@@ -608,17 +621,31 @@ export default [
     tests: [
       {
         deepEqual: true,
-        description: 'simple react elements are deeply equal',
+        description: 'react element compared with itself',
+        shallowEqual: true,
+        value1: reactElementA,
+        value2: reactElementA,
+      },
+      {
+        deepEqual: true,
+        description: 'react elements equal in value',
         shallowEqual: false,
-        value1: React.createElement('div', {}, 'foo'),
-        value2: React.createElement('div', {}, 'foo'),
+        value1: reactElementA,
+        value2: reactElementA2,
       },
       {
         deepEqual: false,
-        description: 'simple react elements are not deeply equal',
+        description: 'react elements unequal by value',
         shallowEqual: false,
-        value1: React.createElement('div', {}, 'foo'),
-        value2: React.createElement('div', {}, 'bar'),
+        value1: reactElementA,
+        value2: reactElementB,
+      },
+      {
+        deepEqual: false,
+        description: 'react elements equal in value but different types',
+        shallowEqual: false,
+        value1: reactElementA,
+        value2: reactElementC,
       },
     ],
   },

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -81,10 +81,6 @@ for (const name in packages) {
   for (const testSuite of tests) {
     const { description } = testSuite;
 
-    if (description !== 'maps' && description !== 'sets') {
-      continue;
-    }
-
     if (!typesBenches[description]) {
       typesBenches[description] = new Bench({ iterations });
     }

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -6,7 +6,9 @@ import type {
   TypedArray,
 } from './internalTypes';
 
-const OWNER = '_owner';
+const PREACT_VNODE = '__v';
+const PREACT_OWNER = '__o';
+const REACT_OWNER = '_owner';
 
 const { getOwnPropertyDescriptor, keys } = Object;
 
@@ -158,11 +160,16 @@ export function areObjectsEqual(
     property = properties[index]!;
 
     if (
-      property === OWNER &&
-      (a.$$typeof || b.$$typeof) &&
-      a.$$typeof !== b.$$typeof
+      (property === REACT_OWNER ||
+        property === PREACT_OWNER ||
+        property === PREACT_VNODE) &&
+      (a.$$typeof || b.$$typeof)
     ) {
-      return false;
+      if (a.$$typeof !== b.$$typeof) {
+        return false;
+      }
+
+      continue;
     }
 
     if (
@@ -204,18 +211,20 @@ export function areObjectsEqualStrict(
     property = properties[index]!;
 
     if (
-      property === OWNER &&
-      (a.$$typeof || b.$$typeof) &&
-      a.$$typeof !== b.$$typeof
+      (property === REACT_OWNER ||
+        property === PREACT_OWNER ||
+        property === PREACT_VNODE) &&
+      (a.$$typeof || b.$$typeof)
     ) {
-      return false;
-    }
+      if (a.$$typeof !== b.$$typeof) {
+        return false;
+      }
 
-    if (!hasOwn(b, property)) {
-      return false;
+      continue;
     }
 
     if (
+      !hasOwn(b, property) ||
       !state.equals(a[property], b[property], property, property, a, b, state)
     ) {
       return false;

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -150,32 +150,12 @@ export function areObjectsEqual(
     return false;
   }
 
-  let property: string;
-
   // Decrementing `while` showed faster results than either incrementing or
   // decrementing `for` loop and than an incrementing `while` loop. Declarative
   // methods like `some` / `every` were not used to avoid incurring the garbage
   // cost of anonymous callbacks.
   while (index-- > 0) {
-    property = properties[index]!;
-
-    if (
-      (property === REACT_OWNER ||
-        property === PREACT_OWNER ||
-        property === PREACT_VNODE) &&
-      (a.$$typeof || b.$$typeof)
-    ) {
-      if (a.$$typeof !== b.$$typeof) {
-        return false;
-      }
-
-      continue;
-    }
-
-    if (
-      !hasOwn(b, property) ||
-      !state.equals(a[property], b[property], property, property, a, b, state)
-    ) {
+    if (!isPropertyEqual(a, b, state, properties[index]!)) {
       return false;
     }
   }
@@ -210,23 +190,7 @@ export function areObjectsEqualStrict(
   while (index-- > 0) {
     property = properties[index]!;
 
-    if (
-      (property === REACT_OWNER ||
-        property === PREACT_OWNER ||
-        property === PREACT_VNODE) &&
-      (a.$$typeof || b.$$typeof)
-    ) {
-      if (a.$$typeof !== b.$$typeof) {
-        return false;
-      }
-
-      continue;
-    }
-
-    if (
-      !hasOwn(b, property) ||
-      !state.equals(a[property], b[property], property, property, a, b, state)
-    ) {
+    if (!isPropertyEqual(a, b, state, property)) {
       return false;
     }
 
@@ -362,5 +326,26 @@ export function areUrlsEqual(a: URL, b: URL): boolean {
     a.hash === b.hash &&
     a.username === b.username &&
     a.password === b.password
+  );
+}
+
+function isPropertyEqual(
+  a: Dictionary,
+  b: Dictionary,
+  state: State<any>,
+  property: string | symbol,
+) {
+  if (
+    (property === REACT_OWNER ||
+      property === PREACT_OWNER ||
+      property === PREACT_VNODE) &&
+    (a.$$typeof || b.$$typeof)
+  ) {
+    return true;
+  }
+
+  return (
+    hasOwn(b, property) &&
+    state.equals(a[property], b[property], property, property, a, b, state)
   );
 }


### PR DESCRIPTION
I realized that the test I had for React comparisons were naive because it ignored the possibility of circular children. Also, it did not account for a common React substitute (Preact).