### PR TITLE
chore: set `files` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "bugs": {
     "url": "https://github.com/planttheidea/fast-equals/issues"
   },
+  "files": [
+    "dist",
+    "src",
+    "index.d.ts"
+  ],
   "description": "A blazing fast equality comparison, either shallow or deep",
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.1.0",


### PR DESCRIPTION
Adds `files` such that only the build output and sources are packaged.

npm will automatically include things like the README too.

NOTE: we have to package `src` up since the sourcemaps reference it. arguably a future change should just turn sourcemaps off since none of this is mjnified anyway

Fixes #151