### PR TITLE
[Enhancement] Micro-optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # fast-equals CHANGELOG
 
+## 6.0.1
+
+- Use `.length` instead of `byteLength` for TypedArrays, which avoids V8 slow path on non-8-bit arrays
+- Use `Uint8Array` instead of `Array` for `matchedIndices` storage for denser uninitialized loads
+- Avoid unnecessary `concat` when no symbols exist on strict comparisons
+
 ## 6.0.0
 
 ### Breaking changes

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -308,9 +308,9 @@ export function areSetsEqual(a: Set<any>, b: Set<any>, state: State<any>): boole
  * Whether the TypedArray instances are equal in value.
  */
 export function areTypedArraysEqual(a: TypedArray, b: TypedArray) {
-  let index = a.byteLength;
+  let index = a.length;
 
-  if (b.byteLength !== index || a.byteOffset !== b.byteOffset) {
+  if (b.length !== index || a.byteOffset !== b.byteOffset) {
     return false;
   }
 

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -111,7 +111,7 @@ export function areMapsEqual(a: Map<any, any>, b: Map<any, any>, state: State<an
     return true;
   }
 
-  const matchedIndices = new Array<true | undefined>(size);
+  const matchedIndices = new Uint8Array(size);
   const aIterable = a.entries();
 
   let aResult: IteratorResult<[any, any]>;
@@ -126,7 +126,7 @@ export function areMapsEqual(a: Map<any, any>, b: Map<any, any>, state: State<an
 
     const bIterable = b.entries();
 
-    let hasMatch = false;
+    let hasMatch = 0;
     let matchIndex = 0;
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -147,7 +147,7 @@ export function areMapsEqual(a: Map<any, any>, b: Map<any, any>, state: State<an
         state.equals(aEntry[0], bEntry[0], index, matchIndex, a, b, state)
         && state.equals(aEntry[1], bEntry[1], aEntry[0], bEntry[0], a, b, state)
       ) {
-        hasMatch = matchedIndices[matchIndex] = true;
+        hasMatch = matchedIndices[matchIndex] = 1;
         break;
       }
 
@@ -262,7 +262,7 @@ export function areSetsEqual(a: Set<any>, b: Set<any>, state: State<any>): boole
     return true;
   }
 
-  const matchedIndices = new Array<true | undefined>(size);
+  const matchedIndices = new Uint8Array(size);
   const aIterable = a.values();
 
   let aResult: IteratorResult<any>;
@@ -276,7 +276,7 @@ export function areSetsEqual(a: Set<any>, b: Set<any>, state: State<any>): boole
 
     const bIterable = b.values();
 
-    let hasMatch = false;
+    let hasMatch = 0;
     let matchIndex = 0;
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -289,7 +289,7 @@ export function areSetsEqual(a: Set<any>, b: Set<any>, state: State<any>): boole
         !matchedIndices[matchIndex]
         && state.equals(aResult.value, bResult.value, aResult.value, bResult.value, a, b, state)
       ) {
-        hasMatch = matchedIndices[matchIndex] = true;
+        hasMatch = matchedIndices[matchIndex] = 1;
         break;
       }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,9 @@ export function createIsCircular<AreItemsEqual extends EqualityComparator<any>>(
  * not enumerable and symbol properties.
  */
 export function getStrictProperties(object: AnyObject): Array<string | symbol> {
-  return (getOwnPropertyNames(object) as Array<string | symbol>).concat(getOwnPropertySymbols(object));
+  const symbols = getOwnPropertySymbols(object);
+  
+  return symbols.length ? (getOwnPropertyNames(object) as Array<string | symbol>).concat(symbols) : getOwnPropertyNames(object);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,8 +53,10 @@ export function createIsCircular<AreItemsEqual extends EqualityComparator<any>>(
  */
 export function getStrictProperties(object: AnyObject): Array<string | symbol> {
   const symbols = getOwnPropertySymbols(object);
-  
-  return symbols.length ? (getOwnPropertyNames(object) as Array<string | symbol>).concat(symbols) : getOwnPropertyNames(object);
+
+  return symbols.length
+    ? (getOwnPropertyNames(object) as Array<string | symbol>).concat(symbols)
+    : getOwnPropertyNames(object);
 }
 
 /**


### PR DESCRIPTION
## Reason for change

An AI review identified a couple of zero-risk cheap wins for edge cases.

## Change

- Use `.length` instead of `.byteLength` in TypedArray comparisons, which avoids de-opt in arrays that are not 8-bit
- Use `Uint8Array` instead of `Array` for the internal `matchedIndices` state tracking, which avoids holey elements
- Avoid unnecessary `.concat()` call when checking strict properties when no symbols exist